### PR TITLE
Implemented --reporter-html-no-success-assertions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ var fs = require('fs'),
  * @param {Object} options - The set of HTML reporter run options.
  * @param {String=} options.template - Optional path to the custom user defined HTML report template (Handlebars).
  * @param {String=} options.export - Optional custom path to create the HTML report at.
+ * @param {Boolean=} options.noSuccessAssertions - Boolean flag to toggle reporting successful tests/assertions.
  * @param {Object} collectionRunOptions - The set of all the collection run options.
  * @returns {*}
  */
@@ -153,6 +154,20 @@ PostmanHTMLReporter = function (newman, options, collectionRunOptions) {
             };
 
         _.forEach(this.summary.run.executions, aggregator);
+
+        // If successful assertions need to be skipped in output then
+        // delete such assertions from the aggregated report
+        if (options.noSuccessAssertions) {
+            _.forEach(aggregations, function (reporterData) {
+                if (reporterData.executions) {
+                    _.forEach(reporterData.executions, function (execData) {
+                        execData.assertions = execData.assertions.filter(function (assertionElement) {
+                            return assertionElement.failed !== 0;
+                        });
+                    });
+                }
+            });
+        }
 
         this.exports.push({
             name: 'html-reporter',

--- a/test/integration/cli.test.js
+++ b/test/integration/cli.test.js
@@ -1,4 +1,7 @@
 const fs = require('fs');
+const _ = require('lodash');
+
+var htmlErrorTable = '<thead><tr><th>Name</th><th>Pass count</th><th>Fail count</';
 
 describe('Newman CLI', function () {
     const outFile = 'out/newman-report.html',
@@ -57,6 +60,35 @@ describe('Newman CLI', function () {
             function (code) {
                 expect(code, 'should have exit code of 1').to.equal(1);
                 fs.stat(outFile, done);
+            });
+    });
+
+    // eslint-disable-next-line max-len
+    it('should correctly produce the html report when successful assertions are to be suppressed (failing assertion)', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`${newman} run test/fixtures/single-request-failing.json -r html --reporter-html-no-success-assertions --reporter-html-export ${outFile}`,
+            function (code) {
+                expect(code, 'should have exit code of 1').to.equal(1);
+                fs.readFile(outFile, 'utf8', function (err, contents) {
+                    expect(err).to.be.null;
+                    expect(_.includes(contents, htmlErrorTable), 'assertion table should be present').to.be.true;
+                    done();
+                });
+            });
+    });
+
+    // eslint-disable-next-line max-len
+    it('should correctly produce the html report when successful assertions are to be suppressed (passing assertion)', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`${newman} run test/fixtures/single-get-request.json -r html --reporter-html-no-success-assertions --reporter-html-export ${outFile}`,
+            function (code) {
+                expect(code, 'should have exit code of 0').to.be.equal(0);
+
+                fs.readFile(outFile, 'utf8', function (err, contents) {
+                    expect(err).to.be.null;
+                    expect(_.includes(contents, htmlErrorTable), 'assertion table should not be present').to.be.false;
+                    done();
+                });
             });
     });
 });

--- a/test/integration/library.test.js
+++ b/test/integration/library.test.js
@@ -1,4 +1,7 @@
-var fs = require('fs');
+var fs = require('fs'),
+    _ = require('lodash'),
+
+    htmlErrorTable = '<thead><tr><th>Name</th><th>Pass count</th><th>Fail count</';
 
 describe('Newman Library', function () {
     var outFile = 'out/newman-report.html';
@@ -68,6 +71,40 @@ describe('Newman Library', function () {
             expect(err).to.be.null;
             expect(summary.run.failures, 'should have 1 failure').to.have.lengthOf(1);
             fs.stat(outFile, done);
+        });
+    });
+
+    // eslint-disable-next-line max-len
+    it('should correctly produce the html report when successful assertions are to be suppressed (failing assertion)', function (done) {
+        newman.run({
+            collection: 'test/fixtures/single-request-failing.json',
+            reporters: ['html'],
+            reporter: { html: { export: outFile, noSuccessAssertions: true } }
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.failures, 'should have 1 failure').to.have.lengthOf(1);
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                expect(_.includes(contents, htmlErrorTable), 'assertion table should be present').to.be.true;
+                done();
+            });
+        });
+    });
+
+    // eslint-disable-next-line max-len
+    it('should correctly produce the html report when successful assertions are to be suppressed (passing assertion)', function (done) {
+        newman.run({
+            collection: 'test/fixtures/single-get-request.json',
+            reporters: ['html'],
+            reporter: { html: { export: outFile, noSuccessAssertions: true } }
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.failures, 'should have 0 failure').to.have.lengthOf(0);
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                expect(_.includes(contents, htmlErrorTable), 'assertion table should not be present').to.be.false;
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
Fixes postmanlabs/newman#1902

### What does this PR do?
It allows the user to suppress successful assertions by passing the flags ```--reporter-html-no-success-assertions``` while using the newman cli or if using the library setting the key ```noSuccessAssertions``` to ```true```

### Implementation:
- Changes were made at the end of ```beforeDone``` event. This is was done so that there is no change on calculation and aggregation of stats.
- If ```noSuccessAssertions``` option is present, traverse the executions and each assertion in them. 
- Filter the assertion array by removing the assertions having ```failed=0```. This will be the new assertion array

Here I removed the assertions which have ```failed=0``` rather than something like ```passed=1```. This is done to account for the case when multiple assertions have the same description. Assertions are tracked using their description as a key, so ones with same description will be counted together and may be omitted if we check through the value of```passed``` .

### Testing:
In ```test/integration/library.test.js``` I have added 2 tests each for CLI and library. They check for suppression of assertions when failing cases as present and when they are not. Since the output is deterministic (as the default template is used) I directly matched the string for presence of the assertion table.